### PR TITLE
Remove `xvfb` - Seemingly deprecated

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,8 @@ FROM docker.io/cm2network/steamcmd:root
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install dependencies and run cleanup
-RUN dpkg --add-architecture i386 && \
-    apt-get update && \
-    apt-get install -yq --install-recommends wine64 xvfb && \
+RUN apt-get update && \
+    apt-get install -yq --install-recommends wine64 && \
     apt-get clean autoclean && \
     apt-get autoremove -yq
 
@@ -22,10 +21,14 @@ VOLUME [ "/server" ]
 # Switch back to the "steam" user.
 USER ${USER}
 
+# Setup Wine prefix
+ENV WINEDEBUG=-all WINEPREFIX=${HOMEDIR}/.wine WINEARCH=win64
+RUN wineboot --init --end-session
+
 # Set up entrypoint
 COPY ./entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["bash", "/entrypoint.sh"]
 
 # Use these for development if the container is crashing.
-# ENTRYPOINT [ "tail" ]
+# CMD ["tail", "-f", "/dev/null"]
 # SHELL [ "/bin/bash" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,10 +17,11 @@ services:
       - Port=7777
       - QueryPort=27015
       - ServerPassword=123
-      - SteamServerName='Local Dev Server'
+      - SteamServerName=Local Dev Server
       - UsePerfThreads=true
       - NoAsyncLoadingThread=true
       - WorldSaveName=dev
+      - AdditionalArgs=-AdminPassword=321 -log -newconsole
       # - AutoUpdate=true
     ports:
       - "7777:7777/udp"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -49,9 +49,16 @@ fi
 
 pushd /server/AbioticFactor/Binaries/Win64 > /dev/null
 
-# xvfb-run is used to fix certain Wine errors since it expects a display server to be available
-xvfb-run wine AbioticFactorServer-Win64-Shipping.exe $SetUsePerfThreads$SetNoAsyncLoadingThread-MaxServerPlayers=$MaxServerPlayers \
-    -PORT=$Port -QueryPort=$QueryPort -ServerPassword=$ServerPassword \
-    -SteamServerName="$SteamServerName" -WorldSaveName="$WorldSaveName" -tcp $AdditionalArgs
+wine AbioticFactorServer-Win64-Shipping.exe \
+    $SetUsePerfThreads \
+    $SetNoAsyncLoadingThread \
+    -MaxServerPlayers=$MaxServerPlayers \
+    -PORT=$Port \
+    -QueryPort=$QueryPort \
+    -ServerPassword=$ServerPassword \
+    -SteamServerName="$SteamServerName" \
+    -WorldSaveName="$WorldSaveName" \
+    -tcp \
+    $AdditionalArgs
 
 popd > /dev/null


### PR DESCRIPTION
- Optimize Wine init to remove errors
- Minor formatting changes
- Remove i386 dependencies since it's not used